### PR TITLE
Update AbstractTable.php

### DIFF
--- a/Mvc/Service/Db/AbstractTable.php
+++ b/Mvc/Service/Db/AbstractTable.php
@@ -46,7 +46,8 @@ abstract class AbstractTable extends Base
             if (is_int($index) && is_array($where)) {
                 call_user_func_array(array($query, 'where'), $where);
             } else {
-                $query->where("{$index} = ?", $where);
+                call_user_func_array(array($query, 'where'), $key);
+                break;
             }
         }
     }


### PR DESCRIPTION
修复当 $key 只一个条件，即一维数组时，条件写死为 `=` 的BUG
比如 $key = array('name like', "'%abc%'")
