### PR TITLE
Update Insert.php

### DIFF
--- a/Db/Query/Insert.php
+++ b/Db/Query/Insert.php
@@ -31,7 +31,7 @@ class Insert extends AbstractQuery
      * @access public
      * @return Insert
      */
-    public function where($condition)
+    public function where()
     {
         return $this;
     }
@@ -43,7 +43,7 @@ class Insert extends AbstractQuery
      * @access public
      * @return Insert
      */
-    public function orWhere($condition)
+    public function orWhere()
     {
         return $this;
     }


### PR DESCRIPTION
fix notice:
Strict Standards: Declaration of TE\Db\Query\Insert::where() should be compatible with that of TE\Db\Query\AbstractQuery::where() in \Db\Query\Insert.php on line 14
