### PR TITLE
preg_replace() 的 deprecated 警告

### DIFF
--- a/Mvc/Data/AbstractData.php
+++ b/Mvc/Data/AbstractData.php
@@ -159,7 +159,9 @@ abstract class AbstractData extends Base implements \Iterator, \Countable, \Arra
         }
 
         $method = 'get' . ucfirst($name);
-        $key = trim(preg_replace("/([A-Z])/e", "'_' . strtolower('\\1')", $name), '_');
+        $key = trim(preg_replace_callback("/([A-Z])/", function($matches){
+            return '_' . strtolower($matches[1]);
+        } , $name), '_');
         if (array_key_exists($name, $this->_data[$this->_pos])) {
             return $this->_data[$this->_pos][$name];
         } else if (array_key_exists($key, $this->_data[$this->_pos])) {


### PR DESCRIPTION
preg_replace()  因为用了修饰符“e”而报 deprecated 错误，换成 preg_replace_callback() 。
